### PR TITLE
Allows clients to set a header to requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-graphql-client",
-	"version": "0.0.1",
+	"version": "0.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -511,9 +511,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",

--- a/src/models/GraphqlRequest.ts
+++ b/src/models/GraphqlRequest.ts
@@ -1,11 +1,16 @@
 export class GraphqlRequest {
-    api: string;
-    query: string;
-    variables: any;
+    constructor(
+        readonly api: string,
+        readonly header: HeaderObject,
+        readonly query: string,
+        readonly variables: VariablesObject
+    ) {}
+}
 
-    constructor(api: string, query: string, variables = {}) {
-        this.api = api;
-        this.query = query;
-        this.variables = variables;
-    }
+export interface HeaderObject {
+    [key: string]: string;
+}
+
+export interface VariablesObject {
+    [key: string]: string;
 }

--- a/src/models/GraphqlRequest.ts
+++ b/src/models/GraphqlRequest.ts
@@ -1,9 +1,9 @@
 export class GraphqlRequest {
     constructor(
-        readonly api: string,
-        readonly header: HeaderObject,
-        readonly query: string,
-        readonly variables: VariablesObject
+        public api: APIObject,
+        public header: HeaderObject,
+        public query: string,
+        public variables: VariablesObject
     ) {}
 }
 
@@ -13,4 +13,9 @@ export interface HeaderObject {
 
 export interface VariablesObject {
     [key: string]: string;
+}
+
+export interface APIObject {
+    method: string;
+    url: string;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,108 +1,77 @@
-import { EOL } from 'os';
-import { GraphqlRequest } from './models/GraphqlRequest';
-import { GraphQLError } from 'graphql';
+import {
+    GraphqlRequest,
+    HeaderObject,
+    VariablesObject
+} from './models/GraphqlRequest';
 import { parse as gqlParse } from 'graphql/language';
+import { EOL } from 'os';
 
 export class Parser {
-    public static parse(text: String): GraphqlRequest {
-        let linesWithVariables: string[] = text.trim().split('variables:');
-        let api;
-        let query;
-        let variables;
-
-        // Break text into multiple lines
-        if (linesWithVariables.length === 0) {
+    public static parse(text: string): GraphqlRequest {
+        if (text.trim().length === 0) {
             throw Error('Selected text cannot be empty');
         }
-        let lines: string[] = linesWithVariables[0].split(EOL);
-        lines = lines.map(line => line.trim()).filter(line => line.length > 0);
 
-        // Get api from text
-        try {
-            api = this.getApi(lines[0]);
-        } catch (err) {
-            throw new Error(err.message);
+        let [head, query, tmpVars] = text.trim().split(EOL + EOL);
+
+        let [api, ...tmpHeader] = head.trim().split(EOL);
+        this.validateAPI(api);
+        const header = this.parseHeader(tmpHeader);
+        this.validateQuery(query);
+        const variables = this.getVariables(tmpVars);
+
+        return new GraphqlRequest(api, header, query, variables);
+    }
+
+    private static validateAPI(api: string): void {
+        // api should start with a GET or POST request method
+        // followed by a space
+        let [method, url] = api.split(' ');
+
+        if (!['GET', 'POST'].includes(method.toUpperCase())) {
+            throw new Error('Invalid request method');
         }
 
-        // Get Query from Text
-        try {
-            query = this.getQuery(lines);
-        } catch (err) {
-            throw new Error(err.message);
-        }
-        if (linesWithVariables.length === 2) {
-            let variableLine: string[] = linesWithVariables[1].split(EOL);
-            variableLine = variableLine.map(line => line.trim()).filter(line => line.length > 0);
-            variables = this.getVariables(variableLine);
-            return new GraphqlRequest(api, query, variables);
-        }
-        else {
-            return new GraphqlRequest(api, query);
+        if (url.trim().length === 0) {
+            throw new Error('No endpoint url');
         }
     }
 
-    private static getApi(line: string): string {
-        // `line` has the format of `POST anAPI`
-        // e.g. `POST https://spotify-graphql-server.herokuapp.com/graphql`
-        line = line.trim();
-        let firstWord = line.slice(0, 4);
-        if (firstWord.toUpperCase() !== 'POST') {
-            throw new Error('The first line must start with \'Post\'');
-        }
-        let urlLink = line.slice(5);
-        urlLink.trimLeft();
-
-        if (urlLink === '') {
-            throw new Error('API must be specified');
-        }
-
-        let EntireAPILink = line.split('\n');
-        let Link = EntireAPILink[0];
-        let urlArray = Link.split(firstWord);
-        let newUrlLink = urlArray[1].trimLeft();
-        
-        return newUrlLink;
-
-    }
-
-    private static getQuery(lines: string[]): string {
-        // `query` has the format of `Graphql Query`
-        //  return the query from the Graphql Request
-        if (lines.length === 0) {
-            throw new Error('Query must be specified');
-        }
-
-        // Concatenate lines
-        let query = lines.join(EOL);
-        let newQuery = query.split('\n');
-        let returnQuery = newQuery.slice(1);
-        let newReturnQuery = returnQuery.join(EOL);
-        // Use builtin parser to parse query
-        try {
-            // build in parser for graphql
-            // it will validate the query
-            // if there is an we will catch it
-             gqlParse(newReturnQuery);
-        } catch (err) {
-            // Be  A N G E R Y (perhaps depending on error type)
-            if (err instanceof GraphQLError) {
-                throw err;
-            } else {
-                throw err;
+    private static parseHeader(header: string[]): HeaderObject {
+        if (header.length === 0) return {};
+        let tmp = header.reduce((result: HeaderObject, current) => {
+            let [key, value] = current.trim().split(':');
+            if (!value) {
+                throw new Error('Ivalid header');
             }
-        }
-        // return query as a string
-        return newReturnQuery;
+            result[key] = value.trim();
+            return result;
+        }, {});
+        return tmp;
     }
 
-    private static getVariables(lines: string[]): string {
-        // string is pre-processed
-        /// all we need is
-        if (lines.length === 0) {
-            throw new Error('Query needs to be specified');
+    private static validateQuery(query: string): void {
+        try {
+            gqlParse(query.trim());
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    private static getVariables(tmpVars: string): VariablesObject {
+        if (tmpVars.trim().length === 0) return {};
+        if (!tmpVars.match(/^ *variables *:/)) {
+            throw new Error('Invalid variables syntax');
         }
 
-        let variable = lines.join(EOL);
-        return JSON.parse(variable);
+        tmpVars = tmpVars
+            .split(':')
+            .filter((v, index) => index > 0)
+            .join(':');
+        try {
+            return JSON.parse(tmpVars.trim());
+        } catch (err) {
+            throw err;
+        }
     }
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,14 +1,22 @@
-import { request } from 'graphql-request';
+import { GraphQLClient } from 'graphql-request';
 import * as _ from 'lodash';
 import { GraphqlRequest } from '../models/GraphqlRequest';
 import { GraphqlResponse } from '../models/GraphqlResponse';
 
-export const getResponse = (gplRequest: GraphqlRequest): Promise<GraphqlResponse> => {
+export const getResponse = (
+    gplRequest: GraphqlRequest
+): Promise<GraphqlResponse> => {
     return new Promise((resolve, reject) => {
-        const endpoint = gplRequest.api;
-        const query = gplRequest.query;
-        const variables = gplRequest.variables;
-        (_.isEmpty(variables) ? request(endpoint, query) : request(endpoint, query, variables))
+        const { api, header: headers, query, variables } = gplRequest;
+        const client = new GraphQLClient(
+            api.url,
+            _.isEmpty(variables) ? { headers } : undefined
+        );
+
+        (_.isEmpty(variables)
+            ? client.request(query)
+            : client.request(query, variables)
+        )
             .then(data => {
                 resolve(new GraphqlResponse(data));
             })


### PR DESCRIPTION
## Features:
. Clientes can set a header in request
. Allow introspection queries that uses (GET request)

## Braking changes

###The format clients would write the requests changed
The proposed format is: (Example)
```
POST https://api.github.com/graphql
Authorization: bearer token
 
query($user: String!, $repository: String!, $last: Int!) {
    repositoryOwner(login: $user) {
        id
        repository(name: $repository) {
            issues(last: $last) {
            nodes {
                title
            }
        }
    }
}

variables: {
     "user": "argobot76",
     "repository": "vscode-graphql-client",
     "last": 10
}
```

1. There `MUST` be at least one empty separating **header**, **query** and **variables**.
2. The first line with content `MUST` be the **method** (GET or POST) followed by the **url**.
3. There can be one or more headers (each one in it's line) in the lines immediately following the previous one.

Resolves #1.

